### PR TITLE
fix: set default weekend schedule for renovate

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,5 +7,8 @@
   "configMigration": true,
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "osvVulnerabilityAlerts": true,
+  "schedule": [
+    "before 9am on Saturday"
+  ],
   "timezone": "America/New_York"
 }


### PR DESCRIPTION
k8s-homelab keeps hitting the github api rate limit because of misc repos all querying hourly